### PR TITLE
Update README with client initialization and transaction usage in Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # blastengine-go
 Blastengine Golang SDK
+
+## クライアントの初期化
+
+クライアントを初期化するには、ユーザーIDとAPIキーを使用して`Initialize`関数を使用します:
+
+```go
+package main
+
+import (
+    "fmt"
+    "blastengine"
+)
+
+func main() {
+    userID := "your_user_id"
+    apiKey := "your_api_key"
+    client := blastengine.Initialize(userID, apiKey)
+    fmt.Println("クライアントが初期化されました。UserID:", client.UserID)
+}
+```
+
+## トランザクションの使用
+
+トランザクションを使用するには、まずクライアントを初期化し、次に`Transaction`メソッドを使用してトランザクションを作成します。トランザクションの件名、テキスト部分、およびHTML部分を設定し、それを送信します:
+
+```go
+package main
+
+import (
+    "blastengine"
+)
+
+func main() {
+    client := blastengine.Initialize("your_user_id", "your_api_key")
+    transaction := client.Transaction()
+
+    transaction.SetSubject("テストメールの件名")
+    transaction.SetTextPart("テストメールの本文")
+    transaction.SetHtmlPart("<h1>テストメールの本文</h1>")
+
+    // トランザクションメールを送信
+    transaction.Send()
+}
+```


### PR DESCRIPTION
Update `README.md` to include instructions for client initialization and transaction usage in Japanese.

* **Client Initialization**
  - Add a section explaining how to initialize the client using the `Initialize` function with user ID and API key.
  - Provide example code demonstrating the initialization process.

* **Transaction Usage**
  - Add a section explaining how to use transactions by first initializing the client and then using the `Transaction` method.
  - Provide example code demonstrating how to set the subject, text part, and HTML part of a transaction and send it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blastengineMania/blastengine-go/pull/7?shareId=c647c006-4b5c-4098-886c-e159e7cdf241).