### PR TITLE
Add generateToken method to client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,5 +1,11 @@
 package blastenginego
 
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+)
+
 type Client struct {
 	apiKey string
 	userId string
@@ -9,4 +15,20 @@ func initializeClient(apiKey string, userId string) Client {
 	// Initialize the client
 	c := Client{apiKey: apiKey, userId: userId}
 	return c
+}
+
+func (c *Client) generateToken() string {
+	// Concatenate userId and apiKey
+	concatenated := c.userId + c.apiKey
+
+	// Generate SHA256 hash
+	hash := sha256.Sum256([]byte(concatenated))
+
+	// Convert hash to lowercase
+	hashString := strings.ToLower(string(hash[:]))
+
+	// Encode in BASE64
+	token := base64.StdEncoding.EncodeToString([]byte(hashString))
+
+	return token
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,11 @@
 package blastenginego
 
-import "testing"
+import (
+	"testing"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+)
 
 func TestInitializeClient(t *testing.T) {
 	apiKey := "testApiKey"
@@ -13,5 +18,18 @@ func TestInitializeClient(t *testing.T) {
 
 	if client.userId != userId {
 		t.Errorf("Expected userId to be %s, but got %s", userId, client.userId)
+	}
+}
+
+func TestGenerateToken(t *testing.T) {
+	apiKey := "testApiKey"
+	userId := "testUserId"
+	client := initializeClient(apiKey, userId)
+
+	expectedToken := "NGY4YjlhNzE0OWYzMTFiNDE5OTJhMmJlYTQxMDlkMmE4MmY1MTNhZWVjNWVhZDRiOGFkNzgxYzZmZmY3MTZjNg=="
+	generatedToken := client.generateToken()
+
+	if generatedToken != expectedToken {
+		t.Errorf("Expected token to be %s, but got %s", expectedToken, generatedToken)
 	}
 }


### PR DESCRIPTION
Add method to generate API request token in `client.go`.

* **client.go**
  - Add `generateToken` method to `Client` struct.
  - Implement token generation by concatenating `userId` and `apiKey`, hashing with SHA256, converting to lowercase, and encoding in BASE64.

* **client_test.go**
  - Add test for `generateToken` method to verify correct token generation.
  - Use sample `userId` and `apiKey` values to validate token generation.
  - Update test script to check if the generated token matches the expected value.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blastengineMania/blastengine-go/pull/11?shareId=705d6e5a-060f-463b-a969-a969048bc6a4).