### PR TITLE
Add generateToken method to Client struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package blastenginego
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"strings"
 )
 
 type Client struct {
@@ -24,11 +23,8 @@ func (c *Client) generateToken() string {
 	// Generate SHA256 hash
 	hash := sha256.Sum256([]byte(concatenated))
 
-	// Convert hash to lowercase string
-	hashString := strings.ToLower(base64.StdEncoding.EncodeToString(hash[:]))
-
-	// Base64 encode the lowercase hash string
-	token := base64.StdEncoding.EncodeToString([]byte(hashString))
+	// Base64 encode the hash string
+	token := base64.StdEncoding.EncodeToString(hash[:])
 
 	return token
 }

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package blastenginego
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 )
 
 type Client struct {
@@ -23,8 +24,11 @@ func (c *Client) generateToken() string {
 	// Generate SHA256 hash
 	hash := sha256.Sum256([]byte(concatenated))
 
-	// Base64 encode the hash string
-	token := base64.StdEncoding.EncodeToString(hash[:])
+	// Convert the hash to a lowercase hexadecimal string
+	hexString := hex.EncodeToString(hash[:])
+
+	// Base64 encode the lowercase hexadecimal string
+	token := base64.URLEncoding.EncodeToString([]byte(hexString))
 
 	return token
 }

--- a/client.go
+++ b/client.go
@@ -1,5 +1,11 @@
 package blastenginego
 
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+)
+
 type Client struct {
 	apiKey string
 	userId string
@@ -9,4 +15,20 @@ func initializeClient(apiKey string, userId string) Client {
 	// Initialize the client
 	c := Client{apiKey: apiKey, userId: userId}
 	return c
+}
+
+func (c *Client) generateToken() string {
+	// Concatenate userId and apiKey
+	concatenated := c.userId + c.apiKey
+
+	// Generate SHA256 hash
+	hash := sha256.Sum256([]byte(concatenated))
+
+	// Convert hash to lowercase string
+	hashString := strings.ToLower(base64.StdEncoding.EncodeToString(hash[:]))
+
+	// Base64 encode the lowercase hash string
+	token := base64.StdEncoding.EncodeToString([]byte(hashString))
+
+	return token
 }

--- a/client_test.go
+++ b/client_test.go
@@ -15,3 +15,16 @@ func TestInitializeClient(t *testing.T) {
 		t.Errorf("Expected userId to be %s, but got %s", userId, client.userId)
 	}
 }
+
+func TestGenerateToken(t *testing.T) {
+	apiKey := "testApiKey"
+	userId := "testUserId"
+	client := initializeClient(apiKey, userId)
+
+	expectedToken := "NGY4YjlhNzE0OWYzMTFiNDE5OTJhMmJlYTQxMDlkMmE4MmY1MTNhZWVjNWVhZDRiOGFkNzgxYzZmZmY3MTZjNg=="
+	token := client.generateToken()
+
+	if token != expectedToken {
+		t.Errorf("Expected token to be %s, but got %s", expectedToken, token)
+	}
+}


### PR DESCRIPTION
Add a method to generate an API request token and corresponding test.

* **client.go**
  - Add `generateToken` method to the `Client` struct.
  - Concatenate `userId` and `apiKey` in the `generateToken` method.
  - Generate a SHA256 hash of the concatenated string.
  - Convert the hash to a lowercase string.
  - Base64 encode the lowercase hash string.

* **client_test.go**
  - Add `TestGenerateToken` method to test the `generateToken` method.
  - Use `apiKey` and `userId` variables with values "testApiKey" and "testUserId".
  - Verify that the generated token matches the expected token "NGY4YjlhNzE0OWYzMTFiNDE5OTJhMmJlYTQxMDlkMmE4MmY1MTNhZWVjNWVhZDRiOGFkNzgxYzZmZmY3MTZjNg==".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blastengineMania/blastengine-go/pull/13?shareId=7e997e96-ba98-4fc8-9103-f1048d30993e).