### PR TITLE
Add Transaction struct with properties and methods

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,58 @@
+package blastenginego
+
+type Transaction struct {
+	From       MailAddress
+	To         string
+	Cc         []string
+	Bcc        []string
+	InsertCode map[string]string
+	Subject    string
+	Encode     string
+	TextPart   string
+	HtmlPart   string
+}
+
+func NewTransaction() *Transaction {
+	return &Transaction{
+		Encode: "UTF-8",
+	}
+}
+
+func (t *Transaction) SetFrom(email, name string) {
+	t.From = NewMailAddress(email, name)
+}
+
+func (t *Transaction) SetTo(to string) {
+	t.To = to
+}
+
+func (t *Transaction) SetCc(cc []string) {
+	t.Cc = cc
+}
+
+func (t *Transaction) SetBcc(bcc []string) {
+	t.Bcc = bcc
+}
+
+func (t *Transaction) SetInsertCode(key string, value string) {
+	if t.InsertCode == nil {
+		t.InsertCode = make(map[string]string)
+	}
+	t.InsertCode[key] = value
+}
+
+func (t *Transaction) SetSubject(subject string) {
+	t.Subject = subject
+}
+
+func (t *Transaction) SetEncode(encode string) {
+	t.Encode = encode
+}
+
+func (t *Transaction) SetTextPart(textPart string) {
+	t.TextPart = textPart
+}
+
+func (t *Transaction) SetHtmlPart(htmlPart string) {
+	t.HtmlPart = htmlPart
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,0 +1,124 @@
+package blastenginego
+
+import "testing"
+
+func TestSetFrom(t *testing.T) {
+	transaction := NewTransaction()
+	email := "test@example.com"
+	name := "Test User"
+	transaction.SetFrom(email, name)
+
+	if transaction.From.Email != email {
+		t.Errorf("Expected From.Email to be %s, but got %s", email, transaction.From.Email)
+	}
+
+	if transaction.From.Name != name {
+		t.Errorf("Expected From.Name to be %s, but got %s", name, transaction.From.Name)
+	}
+}
+
+func TestSetSubject(t *testing.T) {
+	transaction := NewTransaction()
+	subject := "Test subject"
+	transaction.SetSubject(subject)
+
+	if transaction.Subject != subject {
+		t.Errorf("Expected Subject to be %s, but got %s", subject, transaction.Subject)
+	}
+}
+
+func TestSetTo(t *testing.T) {
+	transaction := NewTransaction()
+	to := "user@example.jp"
+	transaction.SetTo(to)
+
+	if transaction.To != to {
+		t.Errorf("Expected To to be %s, but got %s", to, transaction.To)
+	}
+}
+
+func TestSetCc(t *testing.T) {
+	transaction := NewTransaction()
+	cc := []string{"cc1@example.com", "cc2@example.com"}
+	transaction.SetCc(cc)
+
+	if len(transaction.Cc) != len(cc) {
+		t.Errorf("Expected Cc length to be %d, but got %d", len(cc), len(transaction.Cc))
+	}
+
+	for i, v := range cc {
+		if transaction.Cc[i] != v {
+			t.Errorf("Expected Cc[%d] to be %s, but got %s", i, v, transaction.Cc[i])
+		}
+	}
+}
+
+func TestSetBcc(t *testing.T) {
+	transaction := NewTransaction()
+	bcc := []string{"bcc1@example.com", "bcc2@example.com"}
+	transaction.SetBcc(bcc)
+
+	if len(transaction.Bcc) != len(bcc) {
+		t.Errorf("Expected Bcc length to be %d, but got %d", len(bcc), len(transaction.Bcc))
+	}
+
+	for i, v := range bcc {
+		if transaction.Bcc[i] != v {
+			t.Errorf("Expected Bcc[%d] to be %s, but got %s", i, v, transaction.Bcc[i])
+		}
+	}
+}
+
+func TestSetInsertCode(t *testing.T) {
+	transaction := NewTransaction()
+	transaction.SetInsertCode("code1", "value1")
+	transaction.SetInsertCode("code2", "value2")
+
+	if len(transaction.InsertCode) != 2 {
+		t.Errorf("Expected InsertCode length to be %d, but got %d", 2, len(transaction.InsertCode))
+	}
+
+	if transaction.InsertCode["code1"] != "value1" {
+		t.Errorf("Expected InsertCode[code1] to be %s, but got %s", "value1", transaction.InsertCode["code1"])
+	}
+
+	if transaction.InsertCode["code2"] != "value2" {
+		t.Errorf("Expected InsertCode[code2] to be %s, but got %s", "value2", transaction.InsertCode["code2"])
+	}
+}
+
+func TestSetEncode(t *testing.T) {
+	transaction := NewTransaction()
+	encode := "ISO-8859-1"
+	transaction.SetEncode(encode)
+
+	if transaction.Encode != encode {
+		t.Errorf("Expected Encode to be %s, but got %s", encode, transaction.Encode)
+	}
+
+	// Test default value
+	defaultTransaction := NewTransaction()
+	if defaultTransaction.Encode != "UTF-8" {
+		t.Errorf("Expected default Encode to be UTF-8, but got %s", defaultTransaction.Encode)
+	}
+}
+
+func TestSetTextPart(t *testing.T) {
+	transaction := NewTransaction()
+	textPart := "This is a text part"
+	transaction.SetTextPart(textPart)
+
+	if transaction.TextPart != textPart {
+		t.Errorf("Expected TextPart to be %s, but got %s", textPart, transaction.TextPart)
+	}
+}
+
+func TestSetHtmlPart(t *testing.T) {
+	transaction := NewTransaction()
+	htmlPart := "<p>This is an HTML part</p>"
+	transaction.SetHtmlPart(htmlPart)
+
+	if transaction.HtmlPart != htmlPart {
+		t.Errorf("Expected HtmlPart to be %s, but got %s", htmlPart, transaction.HtmlPart)
+	}
+}


### PR DESCRIPTION
Add Transaction struct and methods to set its properties.

* **transaction.go**
  - Define the `Transaction` struct with the specified properties.
  - Implement `NewTransaction` function to initialize a new `Transaction` with default `Encode` value as "UTF-8".
  - Implement `SetFrom` method to set the `From` property.
  - Implement `SetTo` method to set the `To` property.
  - Implement `SetCc` method to set the `Cc` property.
  - Implement `SetBcc` method to set the `Bcc` property.
  - Implement `SetInsertCode` method to set the `InsertCode` property.
  - Implement `SetSubject` method to set the `Subject` property.
  - Implement `SetEncode` method to set the `Encode` property.
  - Implement `SetTextPart` method to set the `TextPart` property.
  - Implement `SetHtmlPart` method to set the `HtmlPart` property.

* **transaction_test.go**
  - Add tests for `SetFrom` method.
  - Add tests for `SetSubject` method.
  - Add tests for `SetTo` method.
  - Add tests for `SetCc` method.
  - Add tests for `SetBcc` method.
  - Add tests for `SetInsertCode` method.
  - Add tests for `SetEncode` method, including a test to confirm the default value is "UTF-8".
  - Add tests for `SetTextPart` method.
  - Add tests for `SetHtmlPart` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blastengineMania/blastengine-go/pull/15?shareId=95f0b93d-5fa6-4529-9e7c-4cd40dbf6488).