### PR TITLE
Implement SendMultipart method in transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"mime/multipart"
+	"os"
+	"path/filepath"
 )
 
 type Transaction struct {
@@ -163,5 +166,123 @@ func (t *Transaction) SendText() error {
 }
 
 func (t *Transaction) SendMultipart() error {
+	url := "https://app.engn.jp/api/v1/deliveries/transaction"
+
+	// Create a buffer to hold the multipart form data
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	// Add the JSON data part
+	dataPart, err := writer.CreateFormField("data")
+	if err != nil {
+		return fmt.Errorf("failed to create form field: %v", err)
+	}
+
+	// Convert InsertCode map to array of key-value pairs with __キー__ format
+	insertCodeArray := make([]map[string]string, 0, len(t.InsertCode))
+	for key, value := range t.InsertCode {
+		insertCodeArray = append(insertCodeArray, map[string]string{"key": "__" + key + "__", "value": value})
+	}
+
+	// Create a temporary struct to hold the modified InsertCode
+	tempTransaction := struct {
+		From       MailAddress         `json:"from"`
+		To         string              `json:"to"`
+		Cc         []string            `json:"cc,omitempty"`
+		Bcc        []string            `json:"bcc,omitempty"`
+		InsertCode []map[string]string `json:"insert_code,omitempty"`
+		Subject    string              `json:"subject"`
+		Encode     string              `json:"encode"`
+		TextPart   string              `json:"text_part"`
+		HtmlPart   string              `json:"html_part,omitempty"`
+	}{
+		From:       t.From,
+		To:         t.To,
+		Cc:         t.Cc,
+		Bcc:        t.Bcc,
+		InsertCode: insertCodeArray,
+		Subject:    t.Subject,
+		Encode:     t.Encode,
+		TextPart:   t.TextPart,
+		HtmlPart:   t.HtmlPart,
+	}
+
+	// Marshal the temporary struct to JSON
+	jsonData, err := json.Marshal(tempTransaction)
+	if err != nil {
+		return fmt.Errorf("failed to marshal transaction: %v", err)
+	}
+
+	_, err = dataPart.Write(jsonData)
+	if err != nil {
+		return fmt.Errorf("failed to write JSON data to form field: %v", err)
+	}
+
+	// Add the file parts
+	for _, attachment := range t.Attachments {
+		file, err := os.Open(attachment)
+		if err != nil {
+			return fmt.Errorf("failed to open attachment: %v", err)
+		}
+		defer file.Close()
+
+		filePart, err := writer.CreateFormFile("file", filepath.Base(attachment))
+		if err != nil {
+			return fmt.Errorf("failed to create form file: %v", err)
+		}
+
+		_, err = io.Copy(filePart, file)
+		if err != nil {
+			return fmt.Errorf("failed to copy file content to form file: %v", err)
+		}
+	}
+
+	// Close the multipart writer to set the terminating boundary
+	err = writer.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close multipart writer: %v", err)
+	}
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("POST", url, &requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Set request headers
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+t.Client.generateToken())
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyString := string(bodyBytes)
+		fmt.Println("Error response:", bodyString)
+		return fmt.Errorf("received non-201 response: %d", resp.StatusCode)
+	}
+
+	// Parse the response body
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	// Parse the response JSON
+	var response struct {
+		DeliveryId int `json:"delivery_id"`
+	}
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+	t.DeliveryId = response.DeliveryId
 	return nil
 }

--- a/transaction.go
+++ b/transaction.go
@@ -173,7 +173,7 @@ func (t *Transaction) SendMultipart() error {
 	writer := multipart.NewWriter(&requestBody)
 
 	// Add the JSON data part
-	dataPart, err := writer.CreateFormField("data")
+	dataPart, err := writer.CreateFormFile("data", "data.json")
 	if err != nil {
 		return fmt.Errorf("failed to create form field: %v", err)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"mime/multipart"
+	"net/http"
+	"net/textproto"
 	"os"
 	"path/filepath"
 )
@@ -173,7 +174,10 @@ func (t *Transaction) SendMultipart() error {
 	writer := multipart.NewWriter(&requestBody)
 
 	// Add the JSON data part
-	dataPart, err := writer.CreateFormFile("data", "data.json")
+	partHeaders := textproto.MIMEHeader{}
+	partHeaders.Set("Content-Disposition", `form-data; name="data"`)
+	partHeaders.Set("Content-Type", "application/json")
+	dataPart, err := writer.CreatePart(partHeaders)
 	if err != nil {
 		return fmt.Errorf("failed to create form field: %v", err)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -190,3 +190,26 @@ func TestSend(t *testing.T) {
 		t.Errorf("Expected DeliveryId to be 0, but got %d", transaction.DeliveryId)
 	}
 }
+
+func TestSendMultipart(t *testing.T) {
+	client := getClient()
+
+	transaction := client.NewTransaction()
+	transaction.SetFrom(os.Getenv("FROM"), "Test User")
+	transaction.SetTo(os.Getenv("TO"))
+	transaction.SetSubject("Test subject")
+	transaction.SetTextPart("This is a text part")
+	transaction.SetHtmlPart("<p>This is an HTML part</p>")
+	transaction.AddAttachment("README.md")
+	transaction.AddAttachment("LICENSE")
+	transaction.Client = &client
+
+	err := transaction.Send()
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	// Check delivery id is up to zero
+	if transaction.DeliveryId == 0 {
+		t.Errorf("Expected DeliveryId to be 0, but got %d", transaction.DeliveryId)
+	}
+}


### PR DESCRIPTION
Implement the `SendMultipart` method in `transaction.go` to handle `multipart/form-data` requests.

* **transaction.go**
  - Add necessary imports for handling multipart form data.
  - Implement the `SendMultipart` method to create a multipart form request.
  - Add the JSON data part to the form.
  - Convert `InsertCode` map to an array of key-value pairs with `__キー__` format.
  - Marshal the modified `InsertCode` into JSON and add it to the form.
  - Add file parts to the form by reading files specified in `Attachments`.
  - Create and send the HTTP request with the multipart form data.
  - Parse the response and set the `DeliveryId`.

* **transaction_test.go**
  - Add a test for the `SendMultipart` method using `README.md` and `LICENSE` as attachments.
  - Verify that the `DeliveryId` is set correctly after sending the multipart request.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blastengineMania/blastengine-go/pull/26?shareId=2e38870d-e8c4-4801-b347-e590d75ea297).