### PR TITLE
Refactor SendText and SendMultipart methods

### DIFF
--- a/blastengine.go
+++ b/blastengine.go
@@ -4,6 +4,15 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
 )
 
 type Client struct {
@@ -38,4 +47,95 @@ func (c *Client) NewTransaction() *Transaction {
 		Client: c,
 	}
 	return transaction
+}
+
+func (c *Client) sendRequest(url string, jsonData []byte, isMultipart bool, attachments []string) (int, error) {
+	var req *http.Request
+	var err error
+
+	if isMultipart {
+		var requestBody bytes.Buffer
+		writer := multipart.NewWriter(&requestBody)
+
+		partHeaders := textproto.MIMEHeader{}
+		partHeaders.Set("Content-Disposition", `form-data; name="data"`)
+		partHeaders.Set("Content-Type", "application/json")
+		dataPart, err := writer.CreatePart(partHeaders)
+		if err != nil {
+			return 0, fmt.Errorf("failed to create form field: %v", err)
+		}
+
+		_, err = dataPart.Write(jsonData)
+		if err != nil {
+			return 0, fmt.Errorf("failed to write JSON data to form field: %v", err)
+		}
+
+		for _, attachment := range attachments {
+			file, err := os.Open(attachment)
+			if err != nil {
+				return 0, fmt.Errorf("failed to open attachment: %v", err)
+			}
+			defer file.Close()
+
+			filePart, err := writer.CreateFormFile("file", filepath.Base(attachment))
+			if err != nil {
+				return 0, fmt.Errorf("failed to create form file: %v", err)
+			}
+
+			_, err = io.Copy(filePart, file)
+			if err != nil {
+				return 0, fmt.Errorf("failed to copy file content to form file: %v", err)
+			}
+		}
+
+		err = writer.Close()
+		if err != nil {
+			return 0, fmt.Errorf("failed to close multipart writer: %v", err)
+		}
+
+		req, err = http.NewRequest("POST", url, &requestBody)
+		if err != nil {
+			return 0, fmt.Errorf("failed to create request: %v", err)
+		}
+
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+	} else {
+		req, err = http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+		if err != nil {
+			return 0, fmt.Errorf("failed to create request: %v", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.generateToken())
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyString := string(bodyBytes)
+		fmt.Println("Error response:", bodyString)
+		return 0, fmt.Errorf("received non-201 response: %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	var response struct {
+		DeliveryId int `json:"delivery_id"`
+	}
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return 0, fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	return response.DeliveryId, nil
 }


### PR DESCRIPTION
Refactor `SendText` and `SendMultipart` methods to use a common network request logic.

* **blastengine.go**
  - Add a new method `sendRequest` to handle common network request logic for both JSON and multipart requests.
  - Implement logic for creating and sending HTTP requests, handling JSON and multipart data, and processing responses.

* **transaction.go**
  - Refactor `SendText` method to use the new `sendRequest` method from `Client`.
  - Refactor `SendMultipart` method to use the new `sendRequest` method from `Client`.
  - Remove redundant network request logic from `SendText` and `SendMultipart` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blastengineMania/blastengine-go/pull/27?shareId=884a9683-0661-421a-930a-b7c1310eb32f).